### PR TITLE
Add root HTTP handler with logging

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -1,33 +1,41 @@
 package main
 
 import (
-    "log"
-    "net/http"
-    "os"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
 
-    "github.com/gorilla/websocket"
+	"github.com/gorilla/websocket"
 )
 
 var upgrader = websocket.Upgrader{
-    CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
 func main() {
-    port := os.Getenv("PORT")
-    if port == "" {
-        port = "8080"
-    }
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
 
-    room := NewRoom()
+	room := NewRoom()
 
-    http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-        conn, err := upgrader.Upgrade(w, r, nil)
-        if err != nil {
-            return
-        }
-        NewPlayer(conn, room)
-    })
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.URL.Path)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, "WebSocket server - open the client at <a href=\"http://localhost:5173\">http://localhost:5173</a>")
+	})
 
-    log.Println("server listening on", port)
-    http.ListenAndServe(":"+port, nil)
+	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.URL.Path)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		NewPlayer(conn, room)
+	})
+
+	log.Println("server listening on", port)
+	http.ListenAndServe(":"+port, nil)
 }


### PR DESCRIPTION
## Summary
- add root route that directs users to the WebSocket client
- log incoming HTTP requests for easier diagnostics

## Testing
- `cd server && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0d1509e608331a5e8f785e8673803