### PR TITLE
Handle WebSocket connection errors

### DIFF
--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -18,6 +18,10 @@ export class Net {
         resolve();
       };
       this.ws.onmessage = (e) => this.handle(e);
+      this.ws.onerror = (e) => {
+        console.error("WebSocket error", e);
+        this.hud.addChat("system", "Connection error. Please refresh to reconnect or check server status.");
+      };
     });
   }
 


### PR DESCRIPTION
## Summary
- forward WebSocket connection errors to HUD
- guide players to refresh or check server status when a connection fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0d271ecf083319b3f182d70f5a665